### PR TITLE
Get rid of repeated "trying peer info"  WARNI-ngs in log

### DIFF
--- a/10-ipfs-config.yml
+++ b/10-ipfs-config.yml
@@ -23,7 +23,8 @@ data:
       ipfs bootstrap rm --all
 
       echo "Avoiding endless WARN log entries for MDNS"
-      ipfs config --bool Discovery.MDNS.Enabled false
+      ipfs config --bool Discovery.MDNS.Enabled true
+      ipfs config --json Discovery.MDNS.Interval 3600
     }
 
     # Always check for secret

--- a/10-ipfs-config.yml
+++ b/10-ipfs-config.yml
@@ -21,6 +21,9 @@ data:
       echo "Removing all bootstrap nodes..."
       echo "(see https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#private-networks)"
       ipfs bootstrap rm --all
+
+      echo "Avoiding endless WARN log entries for MDNS"
+      ipfs config --bool Discovery.MDNS.Enabled false
     }
 
     # Always check for secret

--- a/50ipfs.yml
+++ b/50ipfs.yml
@@ -10,6 +10,10 @@ spec:
     metadata:
       labels:
         app: ipfs
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "5001"
+        prometheus.io/path: "debug/metrics/prometheus"
     spec:
       initContainers:
       - name: init-repo

--- a/50ipfs.yml
+++ b/50ipfs.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: ipfs
 spec:
   serviceName: ipfs
-  replicas: 4
+  replicas: 5
   template:
     metadata:
       labels:

--- a/README.md
+++ b/README.md
@@ -34,25 +34,6 @@ kubectl -n ipfs get pods -o wide
 kubectl -n ipfs exec ipfs-0 -- ipfs swarm peers
 ```
 
-### Ongoing investigation
-
-Remains to investigate this log output
-which repeats itself endlessly:
-```
-DEBUG       mdns: starting mdns query mdns.go:125
-DEBUG       mdns: Handling MDNS entry: 172.17.0.13:4001 QmTgXq7EM2jyArCPAPKsBwdjCmbVqnypXouCxSWQNzPTrP mdns.go:147
-WARNI       core: trying peer info: {<peer.ID TgXq7E> [/ip4/172.17.0.13/tcp/4001]} core.go:390
-DEBUG       mdns: Handling MDNS entry: 172.17.0.14:4001 QmXuE8WGu4pGNuUyz1bsMpwpZrShVDGpokSyWvCMuYCqNA mdns.go:147
-WARNI       core: trying peer info: {<peer.ID XuE8WG> [/ip4/172.17.0.14/tcp/4001]} core.go:390
-DEBUG       core: <peer.ID aoBGog> no more bootstrap peers to create 1 connections bootstrap.go:141
-DEBUG       core: <peer.ID aoBGog> bootstrap error: not enough bootstrap peers to bootstrap bootstrap.go:87
-DEBUG       mdns: Handling MDNS entry: 172.17.0.12:4001 QmUKJ7Fze9kWaxgZR7vUzZzWFgcrAi6AQ3ciX7iCMKw4fn mdns.go:147
-DEBUG       mdns: Handling MDNS entry: 172.17.0.10:4001 QmaoBGogYpHNBhnmpg5e6Hoerc45kdiwvgDEAk1wTrC1H2 mdns.go:147
-DEBUG       mdns: got our own mdns entry, skipping mdns.go:155
-WARNI       core: trying peer info: {<peer.ID UKJ7Fz> [/ip4/172.17.0.12/tcp/4001]} core.go:390
-DEBUG       mdns: mdns query complete mdns.go:138
-```
-
 ## Persistence
 
 Note that ipfs has no ambition to replicate all content across all nodes,


### PR DESCRIPTION
... without breaking discovery or bootstrap.

This is WIP.